### PR TITLE
Alias git to gub only if installed

### DIFF
--- a/bash/github_aliases
+++ b/bash/github_aliases
@@ -1,5 +1,7 @@
-# Alias for hub. It contains all git commans and more
-alias git='hub'
+# Alias for hub. It contains all git commands and more
+if command_exists hub ; then
+    alias git='hub'
+fi
 
 # Open the GitHub page for the current repository
 alias gh='git browse -- /'

--- a/bash_aliases
+++ b/bash_aliases
@@ -1,5 +1,9 @@
 alias sudo='sudo '
 
+command_exists () {
+    type "$1" &> /dev/null ;
+}
+
 source $HOME/.aliases/bash/bash_aliases
 source $HOME/.aliases/bash/git_aliases
 source $HOME/.aliases/bash/github_aliases

--- a/doc/bash/github_aliases.md
+++ b/doc/bash/github_aliases.md
@@ -7,6 +7,11 @@
 
 ### Requirements ###
 Make sure you have the [hub](https://hub.github.com) command installed.
+After you install it reload the aliases for the current terminal window
+by running:
+```bash
+source ~/.aliases/bash_aliases
+```
 
 ### GitHub ###
 - **git**: `hub`


### PR DESCRIPTION
- Alias git to gub only if installed
- Update documentation
- Closes #38 
