### PR TITLE
Add workaround for copying to vagrant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ Enable git aliases: add to `~/.gitconfig`
 [include]
     path = ~/.aliases/git_aliases
 ```
+
+## Using with vagrant
+- clone the repository to a folder of your choice
+- copy `.aliases` to vagrant shared folders (do not forget to add it to `.gitignore` as well)
+- edit `bash_aliases` and replace the line `ALIASES_HOME=$HOME` with your path in vagrant,
+e.g. `ALIASES_HOME='/vagrant'`
+- `source` bash_aliases from its location whenever you ssh into the vagrant box

--- a/bash_aliases
+++ b/bash_aliases
@@ -4,12 +4,14 @@ command_exists () {
     type "$1" &> /dev/null ;
 }
 
-source $HOME/.aliases/bash/bash_aliases
-source $HOME/.aliases/bash/git_aliases
-source $HOME/.aliases/bash/github_aliases
-source $HOME/.aliases/bash/composer_aliases
-source $HOME/.aliases/bash/vim_aliases
-source $HOME/.aliases/bash/symfony_aliases
-source $HOME/.aliases/bash/phpunit_aliases
-source $HOME/.aliases/bash/cordova_aliases
-source $HOME/.aliases/bash/django_aliases
+ALIASES_HOME=$HOME
+
+source $ALIASES_HOME/.aliases/bash/bash_aliases
+source $ALIASES_HOME/.aliases/bash/git_aliases
+source $ALIASES_HOME/.aliases/bash/github_aliases
+source $ALIASES_HOME/.aliases/bash/composer_aliases
+source $ALIASES_HOME/.aliases/bash/vim_aliases
+source $ALIASES_HOME/.aliases/bash/symfony_aliases
+source $ALIASES_HOME/.aliases/bash/phpunit_aliases
+source $ALIASES_HOME/.aliases/bash/cordova_aliases
+source $ALIASES_HOME/.aliases/bash/django_aliases


### PR DESCRIPTION
Issue #39 workaround. For using in vagrant without editing Vagrantfile:
- copy `.aliases` to vagrant shared folders (do not forget to add it to `.gitignore` as well)
- edit `bash_aliases` and replace the line `ALIASES_HOME=$HOME` with your path in vagrant, e.g. ALIASES_HOME='/vagrant'
- `source` bash_aliases from its location when you ssh into the vagrant box
