### PR TITLE
Start composer aliases with co instead of c

### DIFF
--- a/bash/composer_aliases
+++ b/bash/composer_aliases
@@ -1,6 +1,6 @@
 # Composer alias
-alias c='composer'
+alias co='composer'
 
 # Composer install and update aliases
-alias ci='composer install'
-alias cu='composer update'
+alias coi='composer install'
+alias cou='composer update'

--- a/doc/bash/composer_aliases.md
+++ b/doc/bash/composer_aliases.md
@@ -5,8 +5,8 @@
 - [Back to main page](../../README.md)
 
 ### Composer ###
-- **c**: `composer`
+- **co**: `composer`
 
 ### Composer install and update ###
-- **ci**: `composer install`
-- **cu**: `composer update`
+- **coi**: `composer install`
+- **cou**: `composer update`


### PR DESCRIPTION
- Start composer aliases with `co` instead of `c`.
- Closes #28 
