### PR TITLE
Update magento2_aliases

### DIFF
--- a/bash/magento2_aliases
+++ b/bash/magento2_aliases
@@ -1,38 +1,41 @@
+# base magento 2 binary
+alias m2='php bin/magento'
+
 #Install and Upgrade module
-alias m2su='php bin/magento setup:upgrade'
+alias m2su='m2 setup:upgrade'
 
 #Show current mode 
-alias m2dms="php bin/magento deploy:mode:show"
+alias m2dms="m2 deploy:mode:show"
 
 #Deploy static content
-alias m2sscd="php bin/magento setup:static-content:deploy"
+alias m2sscd="m2 setup:static-content:deploy"
 
 #DI compile
-alias m2sdc="php bin/magento setup:di:compile"
+alias m2sdc="m2 setup:di:compile"
 
 #Reindex
-alias m2ir="php bin/magento indexer:reindex"
+alias m2ir="m2 indexer:reindex"
 
 #Cache 
 
 #Flush magento cache
-alias m2cf="php bin/magento cache:flush"
+alias m2cf="m2 cache:flush"
 
 #Clean magento cache 
-alias m2cc="php bin/magento cache:clean"
+alias m2cc="m2 cache:clean"
 
 #Disable full page cache and DDL cache 
-alias m2cddf="php bin/magento cache:disable db_ddl full_page"
+alias m2cddf="m2 cache:disable db_ddl full_page"
 
 #List cache type and status 
-alias m2cs="php bin/magento cache:status"
+alias m2cs="m2 cache:status"
 
 
 #Run Cron job
-alias m2cr="php bin/magento cron:run"
+alias m2cr="m2 cron:run"
 
 #Run automated tests 
-alias m2dtr="php bin/magento dev:test:run"
+alias m2dtr="m2 dev:test:run"
 
 #Display a list of magento commands
-alias m2list="php bin/magento --list"
+alias m2list="m2 --list"


### PR DESCRIPTION
allows for re use and in case "bin/magento" path was different, can be changed only in 1 location.