### PR TITLE
Add git aliases to show sorted branches list.

### DIFF
--- a/bash/git_aliases
+++ b/bash/git_aliases
@@ -7,6 +7,8 @@ alias gr='git rm'
 
 # Git branch alias
 alias gb='git branch -v'
+alias gba='git for-each-ref --sort=committerdate refs/heads/ --format="%(authordate:short) %(color:red)%(objectname:short) %(color:yellow)%(refname:short)%(color:reset) (%(color:green)%(committerdate:relative)%(color:reset))"'
+alias gbd='git for-each-ref --sort=-committerdate refs/heads/ --format="%(authordate:short) %(color:red)%(objectname:short) %(color:yellow)%(refname:short)%(color:reset) (%(color:green)%(committerdate:relative)%(color:reset))"'
 
 # Git commit aliases
 alias gc='git commit'

--- a/doc/bash/git_aliases.md
+++ b/doc/bash/git_aliases.md
@@ -22,6 +22,8 @@
 
 ### Git branch ###
 - **gb**: `git branch -v`
+- **gba**: Shows the `git branch`es list sorted by the last commit time in _ascending_ order
+- **gbd**: Shows the `git branch`es list sorted by the last commit time in _descending_ order
 
 ### Git commit ###
 - **gc**: `git commit`


### PR DESCRIPTION
- add aliases to sort git branch results ascending/descending by branch creation time.