### PR TITLE
Fix conflict with gh command.

### DIFF
--- a/bash/github_aliases
+++ b/bash/github_aliases
@@ -4,7 +4,7 @@ if command_exists hub ; then
 fi
 
 # Open the GitHub page for the current repository
-alias gh='git browse -- /'
+alias ghb='git browse -- /'
 alias ghi='git browse -- /issues'
 alias ghp='git browse -- /pulls'
 alias ghw='git browse -- /wiki'

--- a/doc/bash/github_aliases.md
+++ b/doc/bash/github_aliases.md
@@ -17,7 +17,7 @@ source ~/.aliases/bash_aliases
 - **git**: `hub`
 
 ### Git add and remove ###
-- **gh**: `git browse -- /`
+- **ghb**: `git browse -- /`
 - **ghi** `git browse -- /issues`
 - **ghp**: `git browse -- /pulls`
 - **ghw**: `git browse -- /wiki`


### PR DESCRIPTION
`gh` is now the command for the Github CLI, see: https://cli.github.com/
If people use both, the alias gets picked up and the error is very confusing.
I changed the former alias to ghb.